### PR TITLE
fix(release): derive chart image tags from appVersion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.name }}
           tags: |
-            type=ref,event=tag
+            type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Setup Buildx
@@ -69,7 +69,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ github.event.release.tag_name }}
+            VERSION=${{ steps.meta.outputs.version }}
             ICARUS_VERSION=${{ env.ICARUS_VERSION }}
 
   helm-chart:
@@ -87,7 +87,7 @@ jobs:
       - name: Package chart
         run: |
           version="${GITHUB_REF_NAME#v}"
-          helm package ./mr-cassop --version "$version" --app-version "$GITHUB_REF_NAME"
+          helm package ./mr-cassop --version "$version" --app-version "$version"
 
       - name: Upload chart to release
         uses: softprops/action-gh-release@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,15 +84,6 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - name: Pin chart image tags to release
-        run: |
-          # The image jobs publish each image with the git ref as its tag
-          # (type=ref,event=tag), so the packaged chart must reference that same
-          # tag instead of the placeholder values committed to the repo.
-          sed -i -E "s#(ghcr\.io/${{ github.repository }}/(operator|prober|jolokia|cassandra|icarus)):[^[:space:]]+#\1:${GITHUB_REF_NAME}#g" mr-cassop/values.yaml
-          echo "Pinned chart image tags to ${GITHUB_REF_NAME}:"
-          grep -E "ghcr\.io/${{ github.repository }}/" mr-cassop/values.yaml
-
       - name: Package chart
         run: |
           version="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,15 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Pin chart image tags to release
+        run: |
+          # The image jobs publish each image with the git ref as its tag
+          # (type=ref,event=tag), so the packaged chart must reference that same
+          # tag instead of the placeholder values committed to the repo.
+          sed -i -E "s#(ghcr\.io/${{ github.repository }}/(operator|prober|jolokia|cassandra|icarus)):[^[:space:]]+#\1:${GITHUB_REF_NAME}#g" mr-cassop/values.yaml
+          echo "Pinned chart image tags to ${GITHUB_REF_NAME}:"
+          grep -E "ghcr\.io/${{ github.repository }}/" mr-cassop/values.yaml
+
       - name: Package chart
         run: |
           version="${GITHUB_REF_NAME#v}"

--- a/mr-cassop/Chart.yaml
+++ b/mr-cassop/Chart.yaml
@@ -1,4 +1,6 @@
 apiVersion: v2
+# Release packages override version and appVersion from the GitHub release tag.
+# Do not bump these manually for ordinary changes.
 appVersion: 0.6.0
 description: A Helm chart for Kubernetes, updated for Cassandra 4.1.11 and Kubernetes 1.28+
 name: mr-cassop

--- a/mr-cassop/templates/deployment.yaml
+++ b/mr-cassop/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $imageRepo := "ghcr.io/cin/mr-cassop" -}}
+{{- $imageTag := .Chart.AppVersion -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mr-cassop
-          image: "{{ .Values.container.image }}"
+          image: "{{ .Values.container.image | default (printf "%s/operator:%s" $imageRepo $imageTag) }}"
           imagePullPolicy: {{ .Values.container.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -56,15 +58,15 @@ spec:
             - name: LOGFORMAT
               value: {{ .Values.logFormat | quote }}
             - name: DEFAULT_CASSANDRA_IMAGE
-              value: {{ .Values.cassandraImage | quote }}
+              value: {{ .Values.cassandraImage | default (printf "%s/cassandra:%s" $imageRepo $imageTag) | quote }}
             - name: DEFAULT_PROBER_IMAGE
-              value: {{ .Values.proberImage | quote }}
+              value: {{ .Values.proberImage | default (printf "%s/prober:%s" $imageRepo $imageTag) | quote }}
             - name: DEFAULT_JOLOKIA_IMAGE
-              value: {{ .Values.jolokiaImage | quote }}
+              value: {{ .Values.jolokiaImage | default (printf "%s/jolokia:%s" $imageRepo $imageTag) | quote }}
             - name: DEFAULT_REAPER_IMAGE
               value: {{ .Values.reaperImage | quote }}
             - name: DEFAULT_ICARUS_IMAGE
-              value: {{ .Values.icarusImage | quote }}
+              value: {{ .Values.icarusImage | default (printf "%s/icarus:%s" $imageRepo $imageTag) | quote }}
             - name: WEBHOOKS_ENABLED
               value: {{ .Values.admissionWebhooks.enabled | quote }}
           volumeMounts:

--- a/mr-cassop/values.yaml
+++ b/mr-cassop/values.yaml
@@ -1,6 +1,8 @@
 replicas: 1
 container:
-  image: ghcr.io/cin/mr-cassop/operator:0.6.0
+  # Operator image. Leave empty to default to
+  # ghcr.io/cin/mr-cassop/operator:<chart appVersion>. Set to pin or override.
+  image: ""
   # imagePullSecret: container-registry-secret
   imagePullPolicy: IfNotPresent
   restartPolicy: Always
@@ -13,11 +15,14 @@ container:
       memory: 200Mi
 logLevel: info
 logFormat: json
-proberImage: ghcr.io/cin/mr-cassop/prober:0.6.0
-jolokiaImage: ghcr.io/cin/mr-cassop/jolokia:0.6.0
-cassandraImage: ghcr.io/cin/mr-cassop/cassandra:0.6.0
+# Component images. Leave empty to default to
+# ghcr.io/cin/mr-cassop/<component>:<chart appVersion>. Set to pin or override.
+proberImage: ""
+jolokiaImage: ""
+cassandraImage: ""
+# reaper is an external image and is pinned independently of the chart version.
 reaperImage: thelastpickle/cassandra-reaper:4.2.5
-icarusImage: ghcr.io/cin/mr-cassop/icarus:0.6.0
+icarusImage: ""
 clusterDashboards:
   enabled: []
   namespace: ""

--- a/mr-cassop/values.yaml
+++ b/mr-cassop/values.yaml
@@ -15,7 +15,7 @@ logLevel: info
 logFormat: json
 proberImage: ghcr.io/cin/mr-cassop/prober:0.6.0
 jolokiaImage: ghcr.io/cin/mr-cassop/jolokia:0.6.0
-cassandraImage: ghcr.io/cin/mr-cassop/cassandra:4.1.11-0.6.0
+cassandraImage: ghcr.io/cin/mr-cassop/cassandra:0.6.0
 reaperImage: thelastpickle/cassandra-reaper:4.2.5
 icarusImage: ghcr.io/cin/mr-cassop/icarus:0.6.0
 clusterDashboards:


### PR DESCRIPTION
## Summary

The release should keep the chart and images in lock-step without hardcoded image tags. A release tag like `v0.9.9` now publishes images as clean SemVer tags (`0.9.9`) and packages the Helm chart with both `version` and `appVersion` set to that same stripped version.

Previously, the chart hardcoded image tags in `mr-cassop/values.yaml` (`:0.6.0`, and `cassandra:4.1.11-0.6.0`), while the release workflow published images using the raw git ref. Installing the released chart with defaults could therefore point at image tags the pipeline never produced.

This looks like a leftover from the Cassandra 4 modernization (#76), which switched the release workflow to uniform image tagging without updating the chart defaults.

## Changes

- `release.yml`: use `docker/metadata-action` semver tags (`type=semver,pattern={{version}}`) so releases publish `0.9.9` instead of `v0.9.9`.
- `release.yml`: pass `steps.meta.outputs.version` into the Docker build `VERSION` arg.
- `release.yml`: package the chart with `--version "$version" --app-version "$version"`.
- `templates/deployment.yaml`: default each `cin/mr-cassop` image to `ghcr.io/cin/mr-cassop/<component>:<chart appVersion>`.
- `values.yaml`: remove hardcoded local image tags; empty values mean derive from `appVersion`. `reaperImage` stays pinned (`4.2.5`) because it's external.

## Test plan

- [x] `helm lint ./mr-cassop` passes
- [x] Default render (Chart appVersion `0.6.0`) → all local images `:0.6.0`, reaper `4.2.5`
- [x] Override render (`--set container.image=...:cin --set cassandraImage=...:cin`) → overrides honored
- [x] Release path simulation: `helm package --version 0.9.9 --app-version 0.9.9` then template → all `cin/mr-cassop` images `:0.9.9`, reaper still `4.2.5`
- [ ] Cut a test tag/release and confirm the published chart references resolvable images