### PR TITLE
fix(release): set git author for docs deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,10 @@ jobs:
           USE_SSH: false
           GIT_USER: github-actions[bot]
           GIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           CURRENT_BRANCH: main
           DEPLOYMENT_BRANCH: gh-pages
         run: |


### PR DESCRIPTION
## Summary

The release docs job now gets past the missing `gh-pages` branch, but fails when Docusaurus tries to commit the generated site from its temporary `gh-pages` clone:

```text
Author identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

Docusaurus runs `git commit` inside a temporary clone, so setting repo-local config in the source checkout would not reliably help. This sets `GIT_AUTHOR_*` and `GIT_COMMITTER_*` in the deploy step environment so the child `git commit` process can commit as `github-actions[bot]`.

## Test plan

- [x] Verified the failure is isolated to `docs`; images and helm-chart jobs succeeded in the release run.
- [x] Confirmed the failing command is `git commit` in the Docusaurus deploy temp clone.
- [x] Read lints for `.github/workflows/release.yml`: no linter errors.
- [ ] Re-run the release workflow after merge to confirm docs deploy pushes to `gh-pages`.

Made with [Cursor](https://cursor.com)